### PR TITLE
Deprecate v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,25 @@
 
 Chiketto is a ruby gem for interacting with the Eventbrite V3 API, in Japanese chiketto means 'Ticket'. This library is tested on Ruby 2.0 and above, though may work on 1.9.3.
 
-Chiketto currently falls back to the V1 API when dealing with updating and creating events, though this will change with the 1.0 release.
+## V1 to V3 Update
+
+In version 1.0 Chiketto removed the last remaining uses of the V1 API (creating events and organizers), and moved to exclusively using the V3 API.
+
+Part of the V1 to V3 API change includes a new naming convention for parameters passed to POST requests, the full docs can be found at: http://www.eventbrite.com/developer/v3/
+
+For example pre-V1.0 Chiketto:
+
+```
+Chiketto::Organizer.create name: 'Test Organizer'
+```
+
+Would, in V1.0 become:
+
+```
+Chiketto::Organizer.create 'organizer.name': 'Test Organizer'
+```
+
+In the V3 API version the required fields for each endpoint have also changed, for example, `currency` is now a required field for new events. For full details please refer to the API documentation.
 
 ## Installation
 

--- a/lib/chiketto.rb
+++ b/lib/chiketto.rb
@@ -1,9 +1,9 @@
 module Chiketto
   ENDPOINT = 'https://www.eventbriteapi.com/v3/'
-  LEGACY_ENDPOINT = 'https://www.eventbrite.com/json/'
 
   require 'hash_ext'
 
+  require 'chiketto/exception'
   require 'chiketto/version'
   require 'chiketto/attribute'
   require 'chiketto/attr_attribute'

--- a/lib/chiketto/event.rb
+++ b/lib/chiketto/event.rb
@@ -16,11 +16,8 @@ module Chiketto
               :changed
 
     def self.create(params)
-      params[:title] = params.delete(:name) if params[:name]
-      response = Event.post 'event_new', params
-      if response.fetch('process', false)
-        Event.find response['process']['id']
-      end
+      response = Event.post 'events', params
+      Event.new response
     end
 
     def self.find(id)
@@ -66,12 +63,8 @@ module Chiketto
     end
 
     def update(params)
-      params[:id] = @id
-      params[:title] = params.delete(:name) if params[:name]
-      response = Event.post 'event_update', params
-      if response.fetch('process', false)
-        response['process']['status'].upcase == 'OK'
-      end
+      response = Event.post "events/#{@id}", params
+      Event.new response
     end
 
     def venue

--- a/lib/chiketto/exception.rb
+++ b/lib/chiketto/exception.rb
@@ -1,0 +1,4 @@
+module Chiketto
+  class Exception < StandardError
+  end
+end

--- a/lib/chiketto/organizer.rb
+++ b/lib/chiketto/organizer.rb
@@ -5,12 +5,8 @@ module Chiketto
     attr_attrib :description
 
     def self.create(params)
-      response = Organizer.post 'organizer_new', params
-      if response.fetch('process', false)
-        response['process']['id']
-      elsif response.fetch('error', false)
-        raise response['error']['error_message']
-      end
+      response = Organizer.post 'organizers', params
+      Chiketto::Organizer.new response
     end
   end
 end

--- a/lib/chiketto/resource.rb
+++ b/lib/chiketto/resource.rb
@@ -21,7 +21,7 @@ module Chiketto
     end
 
     def self.post(uri, params = {})
-      uri = URI.parse legacy_endpoint(uri) + query(params)
+      uri = URI.parse endpoint(uri) + query(params)
       resource = open_post uri
       JSON.parse resource
     end
@@ -30,16 +30,16 @@ module Chiketto
       ENDPOINT + uri + token
     end
 
-    def self.legacy_endpoint(uri)
-      LEGACY_ENDPOINT + uri + "?"
-    end
-
     def self.open_post(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri)
       request.add_field 'Authorization', "Bearer #{Chiketto.api_key}"
-      http.request(request).body
+      response = http.request(request)
+      if response.code !~ /20\d/
+        raise Chiketto::Exception, JSON.parse(response.body)
+      end
+      response.body
     end
 
     def self.query(params)

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -135,25 +135,32 @@ class EventTest < MiniTest::Test
   def test_updates_event_with_params
     VCR.use_cassette 'event-update' do
       find_event
-      response = @event.update name: 'Movember 2014'
-      assert response, 'Should return true after updating'
+      event = @event.update 'event.name.html' => 'Movember 2014'
+      assert_kind_of Chiketto::Event, event
       @event = Chiketto::Event.find @event.id
       assert_equal 'Movember 2014', @event.name.to_s
     end
   end
 
   def test_update_returns_false_for_invalid_id
-    VCR.use_cassette 'event-update-fail' do
-      event = Chiketto::Event.new id: '12345'
-      response = event.update name: 'Movember 2014'
-      refute response, 'Should return false for invalid id'
+    VCR.use_cassette 'event-update-failure' do
+      assert_raises Chiketto::Exception do
+        event = Chiketto::Event.new id: '12345'
+        event.update 'event.name.html' => 'Movember 2014'
+      end
     end
   end
 
   def test_create_a_new_event
     VCR.use_cassette 'event-create' do
-      event = Chiketto::Event.create name: 'Test Event Creation',
-        start_date: '2037-12-31 22:59:59', end_date: '2037-12-31 23:59:59'
+      event = Chiketto::Event.create({
+        'event.name.html' => 'Test Event Creation',
+        'event.start.utc' => '2018-05-12T02:00:00Z',
+        'event.start.timezone' => 'Europe/London',
+        'event.end.utc' => '2018-05-12T08:00:00Z',
+        'event.end.timezone' => 'Europe/London',
+        'event.currency' => 'USD',
+      })
       assert_kind_of Chiketto::Event, event
       assert_equal 'Test Event Creation', event.name.to_s
     end
@@ -161,8 +168,9 @@ class EventTest < MiniTest::Test
 
   def test_create_an_event_returns_false_on_failure
     VCR.use_cassette 'event-create-failure' do
-      event = Chiketto::Event.create name: 'Test Event'
-      refute event, 'Should return false when API rejects creation'
+      assert_raises Chiketto::Exception do
+        Chiketto::Event.create 'event.name.html' => 'Test Event'
+      end
     end
   end
 end

--- a/test/organizer_test.rb
+++ b/test/organizer_test.rb
@@ -21,10 +21,18 @@ class OrganizerTest < MiniTest::Test
     assert_respond_to @organizer.description, :text
   end
 
-  def test_cannot_create_an_existing_organizer
+  def test_creating_an_organizer
     VCR.use_cassette 'organizer-create' do
-      assert_raises RuntimeError do
-        Chiketto::Organizer.create name: 'Test Organizer'
+      organizer = Chiketto::Organizer.create 'organizer.name' => 'Test Name'
+      assert_kind_of Chiketto::Organizer, organizer
+      assert_equal 'Test Name', organizer.name
+    end
+  end
+
+  def test_cannot_create_an_existing_organizer
+    VCR.use_cassette 'organizer-create-failure' do
+      assert_raises Chiketto::Exception do
+        Chiketto::Organizer.create 'organizer.name' => 'Test Organizer'
       end
     end
   end

--- a/test/organizer_test.rb
+++ b/test/organizer_test.rb
@@ -23,9 +23,10 @@ class OrganizerTest < MiniTest::Test
 
   def test_creating_an_organizer
     VCR.use_cassette 'organizer-create' do
-      organizer = Chiketto::Organizer.create 'organizer.name' => 'Test Name'
+      name = ENV['CI'] ? Time.new.to_s : 'Test Name'
+      organizer = Chiketto::Organizer.create 'organizer.name' => name
       assert_kind_of Chiketto::Organizer, organizer
-      assert_equal 'Test Name', organizer.name
+      assert_equal name, organizer.name
     end
   end
 


### PR DESCRIPTION
Removes the last remaining uses of the V1 API from the gem, closing #6 